### PR TITLE
fix: close gRPC tool provider connections

### DIFF
--- a/agent/react/agent.go
+++ b/agent/react/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -281,18 +282,30 @@ func (a *Agent) LoadSharedLibPluginTools(ctx context.Context, pluginDir ...strin
 	return nil
 }
 
-func (a *Agent) LoadRPCPluginTools(ctx context.Context, address ...string) error {
-	plugins := make([]toolplugin.ToolPlugin, 0)
-	for _, addr := range address {
-		ps, err := toolplugin.LoadPluginsFromRPC(addr)
-		if err != nil {
-			logging.Errorf("LoadRPCPluginTools error from address %s: %v", addr, err)
-			return err
+func (a *Agent) LoadRPCPluginTools(ctx context.Context, address ...string) ([]io.Closer, error) {
+	plugins := make([]toolplugin.ToolPlugin, 0, len(address))
+	resources := make([]io.Closer, 0, len(address))
+	rollback := func() {
+		for i := len(resources) - 1; i >= 0; i-- {
+			if err := resources[i].Close(); err != nil {
+				logging.Errorf("LoadRPCPluginTools close error: %v", err)
+			}
 		}
+	}
+
+	for _, addr := range address {
+		ps, closer, err := toolplugin.LoadPluginsFromRPC(addr)
+		if err != nil {
+			rollback()
+			logging.Errorf("LoadRPCPluginTools error from address %s: %v", addr, err)
+			return nil, err
+		}
+		resources = append(resources, closer)
 
 		if err := ps.Ping(); err != nil {
+			rollback()
 			logging.Errorf("LoadRPCPluginTools ping error for plugin %s: %v", ps.Name(), err)
-			continue
+			return nil, err
 		}
 
 		plugins = append(plugins, ps)
@@ -307,7 +320,7 @@ func (a *Agent) LoadRPCPluginTools(ctx context.Context, address ...string) error
 		))
 	}
 
-	return nil
+	return resources, nil
 }
 
 func (a *Agent) buildSystemPrompt(

--- a/agent/toolplugin/plugin.go
+++ b/agent/toolplugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"plugin"
@@ -76,9 +77,9 @@ func LoadPluginsFromSharedLib(dir string) ([]ToolPlugin, error) {
 	return plugins, nil
 }
 
-func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
+func LoadPluginsFromRPC(address string) (ToolPlugin, io.Closer, error) {
 	if address == "" {
-		return nil, fmt.Errorf("rpc server address is empty")
+		return nil, nil, fmt.Errorf("rpc server address is empty")
 	}
 
 	conn, err := grpc.NewClient(
@@ -87,7 +88,7 @@ func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
 	)
 	if err != nil {
 		logging.Errorf("Failed to connect to plugin RPC server %s: %v", address, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	client := pb.NewPluginServiceClient(conn)
@@ -100,14 +101,14 @@ func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
 	if err := tool.Init(); err != nil {
 		_ = conn.Close()
 		logging.Errorf("Failed to init plugin RPC server %s: %v", address, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	nameResp, err := client.Name(callCtx, &emptypb.Empty{})
 	if err != nil {
 		_ = conn.Close()
 		logging.Errorf("Failed to get plugin name from RPC server %s: %v", address, err)
-		return nil, err
+		return nil, nil, err
 	}
 	tool.name = nameResp.GetName()
 
@@ -115,7 +116,7 @@ func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
 	if err != nil {
 		_ = conn.Close()
 		logging.Errorf("Failed to get plugin description from RPC server %s: %v", address, err)
-		return nil, err
+		return nil, nil, err
 	}
 	tool.description = descResp.GetDescription()
 
@@ -123,7 +124,7 @@ func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
 	if err != nil {
 		_ = conn.Close()
 		logging.Errorf("Failed to get plugin parameters from RPC server %s: %v", address, err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	toolProperties := make([]common.ToolProperty, 0)
@@ -147,7 +148,7 @@ func LoadPluginsFromRPC(address string) (ToolPlugin, error) {
 	tool.parameters = common.NewToolParameters(toolProperties...)
 
 	logging.Infof("Successfully loaded plugin from RPC server: %s", address)
-	return tool, nil
+	return tool, conn, nil
 }
 
 type rpcToolPlugin struct {

--- a/agent/toolplugin/rpc_lifecycle_test.go
+++ b/agent/toolplugin/rpc_lifecycle_test.go
@@ -1,0 +1,68 @@
+package toolplugin
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/torrischen/goat/agent/toolplugin/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type lifecyclePluginService struct {
+	pb.UnimplementedPluginServiceServer
+}
+
+func (lifecyclePluginService) Init(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (lifecyclePluginService) Name(context.Context, *emptypb.Empty) (*pb.NameResponse, error) {
+	return &pb.NameResponse{Name: "lifecycle"}, nil
+}
+
+func (lifecyclePluginService) Description(context.Context, *emptypb.Empty) (*pb.DescriptionResponse, error) {
+	return &pb.DescriptionResponse{Description: "lifecycle test"}, nil
+}
+
+func (lifecyclePluginService) Properties(context.Context, *emptypb.Empty) (*pb.PropertiesResponse, error) {
+	return &pb.PropertiesResponse{}, nil
+}
+
+func TestRPCPluginCloseClosesConnection(t *testing.T) {
+	address := startLifecyclePluginServer(t)
+	plugin, closer, err := LoadPluginsFromRPC(address)
+	if err != nil {
+		t.Fatalf("LoadPluginsFromRPC() error = %v", err)
+	}
+
+	rpcPlugin, ok := plugin.(*rpcToolPlugin)
+	if !ok {
+		t.Fatalf("plugin type = %T, want *rpcToolPlugin", plugin)
+	}
+
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if got := rpcPlugin.conn.GetState(); got != connectivity.Shutdown {
+		t.Fatalf("connection state = %s, want %s", got, connectivity.Shutdown)
+	}
+}
+
+func startLifecyclePluginServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	pb.RegisterPluginServiceServer(server, lifecyclePluginService{})
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+	return listener.Addr().String()
+}

--- a/goatc/runtime/tool_provider.go
+++ b/goatc/runtime/tool_provider.go
@@ -96,12 +96,15 @@ func (grpcProvider) Load(
 	_ fs.FS,
 	_ string,
 ) ([]io.Closer, error) {
+	addresses := make([]string, 0, len(tools))
 	for _, tool := range tools {
-		if err := agent.LoadRPCPluginTools(ctx, tool.Address); err != nil {
-			return nil, fmt.Errorf("connect to %s: %w", providerLabel(tool), err)
-		}
+		addresses = append(addresses, tool.Address)
 	}
-	return nil, nil
+	resources, err := agent.LoadRPCPluginTools(ctx, addresses...)
+	if err != nil {
+		return nil, fmt.Errorf("connect to gRPC tool providers: %w", err)
+	}
+	return resources, nil
 }
 
 func (mcpProvider) Load(

--- a/goatc/runtime/tool_provider_test.go
+++ b/goatc/runtime/tool_provider_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"net"
 	"net/http/httptest"
@@ -16,12 +17,14 @@ import (
 	pluginpb "github.com/torrischen/goat/agent/toolplugin/pb"
 	"github.com/torrischen/goat/goatc/config"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type testPluginService struct {
 	pluginpb.UnimplementedPluginServiceServer
 	name      string
+	pingErr   error
 	initCalls atomic.Int32
 	pingCalls atomic.Int32
 }
@@ -45,12 +48,38 @@ func (s *testPluginService) Properties(context.Context, *emptypb.Empty) (*plugin
 
 func (s *testPluginService) Ping(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
 	s.pingCalls.Add(1)
+	if s.pingErr != nil {
+		return nil, s.pingErr
+	}
 	return &emptypb.Empty{}, nil
 }
 
+type connectionStats struct {
+	ended chan struct{}
+}
+
+func (*connectionStats) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (*connectionStats) HandleRPC(context.Context, stats.RPCStats) {}
+
+func (*connectionStats) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (s *connectionStats) HandleConn(_ context.Context, event stats.ConnStats) {
+	if _, ok := event.(*stats.ConnEnd); ok {
+		select {
+		case s.ended <- struct{}{}:
+		default:
+		}
+	}
+}
+
 func TestLoadToolProvidersLoadsMultipleGRPCAndMCPServers(t *testing.T) {
-	grpcAddressOne, grpcServiceOne := startTestPluginServer(t, "grpc_one")
-	grpcAddressTwo, grpcServiceTwo := startTestPluginServer(t, "grpc_two")
+	grpcAddressOne, grpcServiceOne, grpcConnectionOne := startTestPluginServer(t, "grpc_one", nil)
+	grpcAddressTwo, grpcServiceTwo, _ := startTestPluginServer(t, "grpc_two", nil)
 	mcpServerOne := startTestMCPServer(t, "mcp_one")
 	mcpServerTwo := startTestMCPServer(t, "mcp_two")
 
@@ -71,10 +100,8 @@ func TestLoadToolProvidersLoadsMultipleGRPCAndMCPServers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadToolProviders() error = %v", err)
 	}
-	defer closeResources(resources)
-
-	if len(resources) != 2 {
-		t.Fatalf("len(resources) = %d, want 2 MCP clients", len(resources))
+	if len(resources) != 4 {
+		t.Fatalf("len(resources) = %d, want 2 gRPC plugins and 2 MCP clients", len(resources))
 	}
 	for _, service := range []*testPluginService{grpcServiceOne, grpcServiceTwo} {
 		if service.initCalls.Load() != 1 {
@@ -84,6 +111,25 @@ func TestLoadToolProvidersLoadsMultipleGRPCAndMCPServers(t *testing.T) {
 			t.Errorf("gRPC Ping calls = %d, want 1", service.pingCalls.Load())
 		}
 	}
+
+	closeResources(resources)
+	waitForConnectionEnd(t, grpcConnectionOne)
+}
+
+func TestGRPCProviderRollsBackConnectionsWhenPingFails(t *testing.T) {
+	firstAddress, _, firstConnection := startTestPluginServer(t, "first", nil)
+	secondAddress, _, secondConnection := startTestPluginServer(t, "second", errors.New("ping failed"))
+	agent := react.NewAgent(nil, 128, ram.NewRAMContextManager())
+
+	_, err := (grpcProvider{}).Load(context.Background(), agent, []config.Tool{
+		{Provider: config.ToolProviderGRPC, Address: firstAddress},
+		{Provider: config.ToolProviderGRPC, Address: secondAddress},
+	}, emptyFS{}, "")
+	if err == nil {
+		t.Fatal("Load() error = nil, want ping error")
+	}
+	waitForConnectionEnd(t, secondConnection)
+	waitForConnectionEnd(t, firstConnection)
 }
 
 func TestExpandValuesUsesRuntimeEnvironment(t *testing.T) {
@@ -96,21 +142,31 @@ func TestExpandValuesUsesRuntimeEnvironment(t *testing.T) {
 	}
 }
 
-func startTestPluginServer(t *testing.T, name string) (string, *testPluginService) {
+func startTestPluginServer(t *testing.T, name string, pingErr error) (string, *testPluginService, *connectionStats) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	server := grpc.NewServer()
-	service := &testPluginService{name: name}
+	connection := &connectionStats{ended: make(chan struct{}, 1)}
+	server := grpc.NewServer(grpc.StatsHandler(connection))
+	service := &testPluginService{name: name, pingErr: pingErr}
 	pluginpb.RegisterPluginServiceServer(server, service)
 	go func() { _ = server.Serve(listener) }()
 	t.Cleanup(func() {
 		server.Stop()
 		_ = listener.Close()
 	})
-	return listener.Addr().String(), service
+	return listener.Addr().String(), service, connection
+}
+
+func waitForConnectionEnd(t *testing.T, connection *connectionStats) {
+	t.Helper()
+	select {
+	case <-connection.ended:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for gRPC connection to close")
+	}
 }
 
 func startTestMCPServer(t *testing.T, toolName string) *httptest.Server {


### PR DESCRIPTION
## Summary                                                                                                           
                                                                                      
   - return gRPC connection closers from RPC plugin loading                                                             
   - propagate connection ownership through `LoadRPCPluginTools`                                                        
   - register gRPC resources with goatc's existing provider cleanup path                                                
   - roll back opened connections when loading or health checks fail                                                    
   - add tests for normal shutdown and partial initialization failure                                                   