### PR TITLE
Feature: use cuid as prompt cache key

### DIFF
--- a/agent/react/agent.go
+++ b/agent/react/agent.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/alitto/pond/v2"
 	"github.com/bytedance/sonic"
+	"github.com/cloudwego/eino-ext/components/model/agenticopenai"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 	"github.com/mark3labs/mcp-go/client"
@@ -659,6 +660,7 @@ func (a *Agent) Do(
 	}
 
 	callOpts := append([]model.Option{}, opts...)
+	callOpts = append(callOpts, agenticopenai.WithResponsesPromptCacheKey(contextUID.String()))
 	agenticTools := a.convertToolsToAgenticFormat(args.EnablePlanning)
 	if len(agenticTools) > 0 {
 		callOpts = append(callOpts, model.WithTools(agenticTools))

--- a/agent/react/events_test.go
+++ b/agent/react/events_test.go
@@ -19,10 +19,11 @@ import (
 )
 
 type scriptedEventModel struct {
-	mu        sync.Mutex
-	responses [][]*schema.AgenticMessage
-	inputs    [][]*schema.AgenticMessage
-	streamErr error
+	mu           sync.Mutex
+	responses    [][]*schema.AgenticMessage
+	inputs       [][]*schema.AgenticMessage
+	optionCounts []int
+	streamErr    error
 }
 
 type failingSettleStore struct {
@@ -71,11 +72,12 @@ func (m *scriptedEventModel) Generate(
 func (m *scriptedEventModel) Stream(
 	_ context.Context,
 	input []*schema.AgenticMessage,
-	_ ...model.Option,
+	opts ...model.Option,
 ) (*schema.StreamReader[*schema.AgenticMessage], error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.inputs = append(m.inputs, common.CloneAgenticMessages(input))
+	m.optionCounts = append(m.optionCounts, len(opts))
 	if m.streamErr != nil {
 		return nil, m.streamErr
 	}
@@ -138,6 +140,40 @@ func TestDoEmitsDirectAnswerLifecycleAndUsage(t *testing.T) {
 		t.Fatalf("run completed = %+v", completed)
 	}
 	assertRunOutcome(t, ctx, store, signature, contextmgr.RunOutcomeCompleted)
+}
+
+func TestDoUsesContextUIDAsPromptCacheKey(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	llm := &scriptedEventModel{responses: [][]*schema.AgenticMessage{
+		{common.AssistantTextMessage("first answer")},
+		{common.AssistantTextMessage("second answer")},
+	}}
+	agent := NewAgent(llm, 128, ram.NewRAMContextManager())
+
+	first, firstEvents, err := agent.Do(ctx, &common.AgentDoArgs{
+		UserInput: common.AgentUserInput{Text: "first request"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	readAllEvents(t, ctx, firstEvents)
+
+	_, secondEvents, err := agent.Do(ctx, &common.AgentDoArgs{
+		ContextUID: first.ContextUID,
+		UserInput:  common.AgentUserInput{Text: "second request"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	readAllEvents(t, ctx, secondEvents)
+
+	llm.mu.Lock()
+	defer llm.mu.Unlock()
+	if !reflect.DeepEqual(llm.optionCounts, []int{1, 1}) {
+		t.Fatalf("model option counts = %v, want one cache option for both generated and provided contexts", llm.optionCounts)
+	}
 }
 
 func TestDoCreatesDistinctRunSignaturesWithinOneConversation(t *testing.T) {


### PR DESCRIPTION
## Summary

use context uid as the prompt cache key in the react agent loop.

## Testing

<!-- List the commands and manual checks used to validate this change. -->

- [x] `gofmt` produces no changes
- [x] `go vet ./...`
- [x] `go test -race ./...`

## Checklist

- [x] I added or updated tests for behavior changes.
- [x] I added GoDoc for new exported identifiers.
- [x] I updated relevant documentation.
- [x] I updated `CHANGELOG.md` when the change is user-visible.
- [x] I did not include credentials, private data, or unrelated changes.
- [x ] I have read and followed `CONTRIBUTING.md`.
